### PR TITLE
Offline sending for testing

### DIFF
--- a/lib/mandrill_mailer/offline.rb
+++ b/lib/mandrill_mailer/offline.rb
@@ -14,6 +14,10 @@
 #   }
 #   expect(email).to_not be_nil
 #
+# Don't forget to clear out deliveries:
+#
+#   before :each { MandrillMailer.deliveries.clear }
+#
 require 'mandrill_mailer'
 
 module MandrillMailer


### PR DESCRIPTION
Following on from the discussion in #29. Turns out this gem's a better place for this (as opposed to the mandrill gem). Here's the deal (also covered in the comments at the top of the file):

Offline modifications for using MandrillMailer without actually sending emails through Mandrill's API. Particularly useful for acceptance tests.

To use, just require this file (say, in your spec_helper.rb):

``` ruby
require 'mandrill_mailer/offline'
```

And then if you wish you can look at the contents of `MandrillMailer.deliveries` to see whether an email was queued up by your test:

``` ruby
email = MandrillMailer::deliveries.detect { |mail|
  mail.template_name == 'my-template' &&
  mail.message['to'].any? { |to| to['email'] == 'my@email.com' }
}
expect(email).to_not be_nil
```

Don't forget to clear out deliveries:

``` ruby
before :each { MandrillMailer.deliveries.clear }
```
