### PR TITLE
Respond to string

### DIFF
--- a/lib/mandrill_mailer/template_mailer.rb
+++ b/lib/mandrill_mailer/template_mailer.rb
@@ -314,7 +314,7 @@ module MandrillMailer
     end
 
     def self.respond_to?(method, include_private = false)
-      super || instance_methods.include?(method)
+      super || instance_methods.include?(method.to_sym)
     end
 
     # Proxy route helpers to rails if Rails exists. Doing routes this way

--- a/spec/template_mailer_spec.rb
+++ b/spec/template_mailer_spec.rb
@@ -319,4 +319,25 @@ describe MandrillMailer::TemplateMailer do
       klassB.mandrill_mail({vars: {}}).message['from_name'].should eq 'ClassB'
     end
   end
+
+  describe '#respond_to' do
+    it 'can respond to a symbol' do
+      klassA = Class.new(MandrillMailer::TemplateMailer) do
+        def test_method
+
+        end
+      end
+
+      klassA.respond_to?(:test_method).should be_true
+    end
+    it 'can respond to a string' do
+      klassA = Class.new(MandrillMailer::TemplateMailer) do
+        def test_method
+
+        end
+      end
+
+      klassA.respond_to?('test_method').should be_true
+    end
+  end
 end


### PR DESCRIPTION
Fixes respond to method as it doesn't follow the way standard ruby respond_to behaves. It should not distinguish between strings and symbols. It only responded to symbols correctly not to strings before this fix.
