### PR TITLE
Improving some doc indents

### DIFF
--- a/lib/mandrill_mailer/template_mailer.rb
+++ b/lib/mandrill_mailer/template_mailer.rb
@@ -115,6 +115,7 @@ module MandrillMailer
     # Public: setup a way to test mailer methods
     #
     # mailer_method - Name of the mailer method the test setup is for
+    # 
     # block - Block of code to execute to perform the test. The mailer
     # and options are passed to the block. The options have to
     # contain at least the :email to send the test to.
@@ -139,6 +140,7 @@ module MandrillMailer
     # Public: Executes a test email
     #
     # mailer_method - Method to execute
+    # 
     # options - The Hash options used to refine the selection (default: {}):
     #   :email - The email to send the test to.
     #


### PR DESCRIPTION
I was trying to figure out how to properly test my mailer and found some mistakes in the comment indents in `lib/mandrill_mailer/template_mailer.rb`. Should be fixed with this tiny change. Still not to sure how to test tho, would love some help with that xD
