### PR TITLE
Updates interceptor example for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,6 @@ Example:
 
 ```ruby
 MandrillMailer.configure do |config|
-  config.interceptor_params = { to: "emailtothatwillbeusedinall@emailssent.com" }
+  config.interceptor_params = { email: { to: "emailtothatwillbeusedinall@emailssent.com" } }
 end
 ```


### PR DESCRIPTION
Using the current example you will receive the API error:

```
Mandrill::ValidationError: Validation error: {"message":{"to":"Please enter an array"}}
```

`to:` is expected to be a Hash that can take `email:` and `name:`
