### PR TITLE
passing through merge language variable

### DIFF
--- a/lib/mandrill_mailer/template_mailer.rb
+++ b/lib/mandrill_mailer/template_mailer.rb
@@ -180,6 +180,7 @@ module MandrillMailer
         "url_strip_qs" => args.fetch(:url_strip_qs, true),
         "preserve_recipients" => args[:preserve_recipients],
         "bcc_address" => args[:bcc],
+        "merge_language" => args[:merge_language],
         "global_merge_vars" => mandrill_args(args[:vars]),
         "merge_vars" => mandrill_rcpt_args(args[:recipient_vars]),
         "tags" => args[:tags],


### PR DESCRIPTION
This is a poorly documented feature of mandrill's api. It allows the use of handlebars in the Mandrill templates.

https://mandrillapp.com/api/docs/messages.curl.html
