### PR TITLE
Update `ENV` var in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ActionMailer::Base.smtp_settings = {
     :address   => "smtp.mandrillapp.com",
     :port      => 587,
     :user_name => ENV['MANDRILL_USERNAME'],
-    :password  => ENV['MANDRILL_PASSWORD'],
+    :password  => ENV['MANDRILL_API_KEY'],
     :domain    => 'heroku.com'
   }
 ActionMailer::Base.delivery_method = :smtp
@@ -68,25 +68,30 @@ class InvitationMailer < MandrillMailer::TemplateMailer
     # in this example `invitation.invitees` is an Array
     invitees = invitation.invitees.map { |invitee| { email: invitee.email, name: invitee.name } }
 
-    mandrill_mail template: 'group-invite',
-                  subject: I18n.t('invitation_mailer.invite.subject'),
-                  to: invitees,
-                  # to: invitation.email,
-                  # to: { email: invitation.email, name: 'Honored Guest' },
-                  vars: {
-                    'OWNER_NAME' => invitation.owner_name,
-                    'PROJECT_NAME' => invitation.project_name
-                  },
-                  important: true,
-                  inline_css: true,
-                  recipient_vars: invitation.invitees.map do |invitee| # invitation.invitees is an Array
-                    { invitee.email =>
-                      {
-                        'INVITEE_NAME' => invitee.name,
-                        'INVITATION_URL' => new_invitation_url(invitee.email, secret: invitee.secret_code)
-                      }
-                    }
-                  end
+    mandrill_mail(
+      template: 'group-invite',
+      subject: I18n.t('invitation_mailer.invite.subject'),
+      to: invitees,
+        # to: invitation.email,
+        # to: { email: invitation.email, name: 'Honored Guest' },
+      vars: {
+        'OWNER_NAME' => invitation.owner_name,
+        'PROJECT_NAME' => invitation.project_name
+      },
+      important: true,
+      inline_css: true,
+      recipient_vars: invitation.invitees.map do |invitee|
+        { invitee.email =>
+          {
+            'INVITEE_NAME' => invitee.name,
+            'INVITATION_URL' => new_invitation_url(
+              invitee.email,
+              secret: invitee.secret_code
+            )
+          }
+        }
+      end
+     )
   end
 end
 ```


### PR DESCRIPTION
- Mandrill API expects ActionMailer `password` to be the API key, not actual
  mandrill password
- This difference confused me at first, so I thought I'd change to README to
  help others
- Also reformatted example JSON to improve readability
