### PR TITLE
Update README about image and attachment content

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ end
    * `:inline_css` - whether or not to automatically inline all CSS styles provided in the message HTML - only for HTML documents less than 256KB in size.
 
    * `:attachments` - An array of file objects with the following keys:
-     * `content`: The file contents, must be a base64 encoded string
+     * `content`: The file contents
      * `name`: The name of the file
      * `type`: This is the mimetype of the file. Ex. png = image/png, pdf = application/pdf, txt = text/plain etc etc
 
    * `:images` - An array of embedded images to add to the message:
-     * `content`: The file contents, must be a base64 encoded string
+     * `content`: The file contents
      * `name`: The name of the file
      * `type`: This is the mimetype of the file. Ex. png = image/png, pdf = application/pdf, txt = text/plain etc etc etc
 
@@ -190,7 +190,7 @@ class InvitationMailer < MandrillMailer::MessageMailer
                   inline_css: true,
                   attachments: [
                     {
-                      content: Base64.encode64(File.read(File.expand_path('assets/offer.pdf'))),
+                      content: File.read(File.expand_path('assets/offer.pdf')),
                       name: 'offer.pdf',
                       type: 'application/pdf'
                     }


### PR DESCRIPTION
The gem is now encoding in base64 the images and the attachments but the documentation still asking us to do it by ourselves.

This could lead people to the wrong usage getting a double base64 encoded content that would seem broken at the email reader.
