### PR TITLE
Add support for default merge_vars

### DIFF
--- a/lib/mandrill_mailer/core_mailer.rb
+++ b/lib/mandrill_mailer/core_mailer.rb
@@ -4,7 +4,9 @@
 # Example usage:
 
 # class InvitationMailer < MandrillMailer::TemplateMailer
-#   default from: 'support@codeschool.com'
+#   default from: 'support@codeschool.com',
+#           from_name: 'Code School',
+#           merge_vars: { 'FOO' => 'Bar' }
 
 #   def invite(invitation)
 #     invitees = invitation.invitees.map { |invitee| { email: invitee.email, name: invitee.name } }
@@ -34,7 +36,9 @@
 # end
 
 # #default:
-#   :from - set the default from email address for the mailer
+#   :from       - set the default from email address for the mailer
+#   :from_name  - set the default from name for the mailer
+#   :merge_vars - set the default merge vars for the mailer
 
 # .mandrill_mail
 #   :template(required) - Template name from within Mandrill
@@ -123,12 +127,17 @@ module MandrillMailer
 
     # Public: Defaults for the mailer. Currently the only option is from:
     #
-    # options - The Hash options used to refine the selection (default: {}):
-    #   :from - Default from email address
+    # options       - The Hash options used to refine the selection (default: {}):
+    #   :from       - Default from email address
+    #   :from_name  - Default from name
+    #   :merge_vars - Default merge vars
     #
     # Examples
     #
-    #   default from: 'foo@bar.com'
+    #   default from: 'foo@bar.com',
+    #           from_name: 'Foo Bar',
+    #           merge_vars: {'FOO' => 'Bar'}
+    #
     #
     # Returns options
     def self.defaults
@@ -316,6 +325,8 @@ module MandrillMailer
 
     # convert a normal hash into the format mandrill needs
     def mandrill_args(args)
+      args = merge_default_merge_vars(args)
+
       return [] unless args
       args.map do |k,v|
         {'name' => k, 'content' => v}
@@ -326,8 +337,12 @@ module MandrillMailer
       return [] unless args
       args.map do |item|
         rcpt = item.keys[0]
-        {'rcpt' => rcpt, 'vars' => mandrill_args(item.fetch(rcpt))}
+        { 'rcpt' => rcpt, 'vars' => mandrill_args(item.fetch(rcpt)) }
       end
+    end
+
+    def merge_default_merge_vars(args)
+      self.class.defaults[:merge_vars].merge(args)
     end
 
     # ensure only true or false is returned given arg

--- a/lib/mandrill_mailer/core_mailer.rb
+++ b/lib/mandrill_mailer/core_mailer.rb
@@ -151,6 +151,7 @@ module MandrillMailer
     def self.default(args)
       @defaults ||= {}
       @defaults[:from] ||= 'example@email.com'
+      @defaults[:merge_vars] ||= {}
       @defaults.merge!(args)
     end
 

--- a/lib/mandrill_mailer/message_mailer.rb
+++ b/lib/mandrill_mailer/message_mailer.rb
@@ -168,7 +168,7 @@ module MandrillMailer
         "preserve_recipients" => args[:preserve_recipients],
         "bcc_address" => args[:bcc],
         "global_merge_vars" => mandrill_args(args[:vars]),
-        "merge_vars" => mandrill_rcpt_args(args[:recipient_vars]),
+        "merge_vars" => mandrill_rcpt_args(args[:recipient_vars] || self.class.defaults[:merge_vars]),
         "tags" => args[:tags],
         "subaccount" => args[:subaccount],
         "google_analytics_domains" => args[:google_analytics_domains],

--- a/lib/mandrill_mailer/template_mailer.rb
+++ b/lib/mandrill_mailer/template_mailer.rb
@@ -4,7 +4,9 @@
 # Example usage:
 
 # class InvitationMailer < MandrillMailer::TemplateMailer
-#   default from: 'support@codeschool.com'
+#   default from: 'support@codeschool.com',
+#           from_name: 'Code School',
+#           merge_vars: { 'FOO' => 'Bar' }
 
 #   def invite(invitation)
 #     invitees = invitation.invitees.map { |invitee| { email: invitee.email, name: invitee.name } }

--- a/spec/template_mailer_spec.rb
+++ b/spec/template_mailer_spec.rb
@@ -360,35 +360,39 @@ describe MandrillMailer::TemplateMailer do
   describe 'defaults' do
     it 'should not share between different subclasses' do
       klassA = Class.new(MandrillMailer::TemplateMailer) do
-        default from_name: 'ClassA'
+        default from_name: 'ClassA', merge_vars: { 'FOO' => 'Bar' }
       end
       klassB = Class.new(MandrillMailer::TemplateMailer) do
         default from_name: 'ClassB'
       end
 
       expect(klassA.mandrill_mail({vars: {}}).message['from_name']).to eq 'ClassA'
+      expect(klassA.mandrill_mail({vars: {}}).message['global_merge_vars']).to include({"name"=>"FOO", "content"=>"Bar"})
       expect(klassB.mandrill_mail({vars: {}}).message['from_name']).to eq 'ClassB'
+      expect(klassB.mandrill_mail({vars: {}}).message['global_merge_vars']).to_not include({"name"=>"FOO", "content"=>"Bar"})
     end
 
     it 'should use defaults from the parent class' do
       klassA = Class.new(MandrillMailer::TemplateMailer) do
-        default from_name: 'ClassA'
+        default from_name: 'ClassA', merge_vars: { 'FOO' => 'Bar' }
       end
       klassB = Class.new(klassA) do
       end
 
-      expect(klassB.mandrill_mail({vars:{}}).message['from_name']).to eq 'ClassA'
+      expect(klassB.mandrill_mail({vars: {}}).message['from_name']).to eq 'ClassA'
+      expect(klassB.mandrill_mail({vars: {}}).message['global_merge_vars']).to include({"name"=>"FOO", "content"=>"Bar"})
     end
 
     it 'should allow overriding defaults from the parent' do
       klassA = Class.new(MandrillMailer::TemplateMailer) do
-        default from_name: 'ClassA'
+        default from_name: 'ClassA', merge_vars: { 'FOO' => 'Bar' }
       end
       klassB = Class.new(klassA) do
-        default from_name: 'ClassB'
+        default from_name: 'ClassB', merge_vars: { 'FOO' => 'Boo' }
       end
 
-      expect(klassB.mandrill_mail({vars:{}}).message['from_name']).to eq 'ClassB'
+      expect(klassB.mandrill_mail({vars: {}}).message['from_name']).to eq 'ClassB'
+      expect(klassB.mandrill_mail({vars: {}}).message['global_merge_vars']).to include({"name"=>"FOO", "content"=>"Boo"})
     end
   end
 


### PR DESCRIPTION
This may allow a default unsubscribe URL to be specified for all mailers for instance.

Works as follows:

```ruby
default from: 'support@codeschool.com',
            from_name: 'Code School',
            merge_vars: { 'FOO' => 'Bar' }
```

One thing I want to explore later on is the idea of making the value of one of those default marge vars dynamic based on the current recipient.

This is a work in progress.