### PR TITLE
Bumped mandrill-api dependency to use the last version

### DIFF
--- a/mandrill_mailer.gemspec
+++ b/mandrill_mailer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport'
   s.add_dependency 'actionpack'
-  s.add_runtime_dependency 'mandrill-api', '~> 1.0.9'
+  s.add_runtime_dependency 'mandrill-api', '>= 1.0.9'
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
# What

This change is needed to use the last versions of `json` gem. Right now it's fixed to `1.7.7`
