### PR TITLE
use proper defaults in ArgFormatter

### DIFF
--- a/lib/mandrill_mailer/arg_formatter.rb
+++ b/lib/mandrill_mailer/arg_formatter.rb
@@ -69,7 +69,7 @@ module MandrillMailer
       end
     end
 
-    def self.format_messages_api_message_data(args)
+    def self.format_messages_api_message_data(args, defaults)
       # If a merge_language attribute is given and it's not one of the accepted
       # languages Raise an error
       if args[:merge_language] && !ACCEPTED_MERGE_LANGUAGES.include?(args[:merge_language])
@@ -110,10 +110,6 @@ module MandrillMailer
         "attachments" => attachment_args(args[:attachments]),
         "images" => images_args(args[:images])
       }
-    end
-
-    def self.defaults
-      MandrillMailer::CoreMailer.defaults
     end
   end
 end

--- a/lib/mandrill_mailer/core_mailer.rb
+++ b/lib/mandrill_mailer/core_mailer.rb
@@ -242,7 +242,7 @@ module MandrillMailer
       mandrill_mail_handler(args)
 
       # Construct message hash
-      self.message = MandrillMailer::ArgFormatter.format_messages_api_message_data(args)
+      self.message = MandrillMailer::ArgFormatter.format_messages_api_message_data(args, self.class.defaults)
 
       # Apply any interceptors that may be present
       apply_interceptors!(self.message)

--- a/spec/arg_formatter_spec.rb
+++ b/spec/arg_formatter_spec.rb
@@ -197,7 +197,7 @@ describe MandrillMailer::ArgFormatter do
 
   describe ".format_messages_api_message_data" do
     it "includes all api values" do
-      result = formatter.format_messages_api_message_data({})
+      result = formatter.format_messages_api_message_data({}, {})
       api_values = ["html", "text", "subject", "from_email", "from_name", "to",
                     "headers", "important", "track_opens", "track_clicks", "auto_text",
                     "auto_html", "inline_css", "url_strip_qs", "preserve_recipients",
@@ -216,20 +216,20 @@ describe MandrillMailer::ArgFormatter do
     context "merge_language exists" do
       context "merge_language is an accepted merge language" do
         it "does not raise an error" do
-          expect { formatter.format_messages_api_message_data({merge_language: "handlebars"}) }.not_to raise_error
+          expect { formatter.format_messages_api_message_data({merge_language: "handlebars"}, {}) }.not_to raise_error
         end
       end
 
       context "merge_language is not an accepted merge language" do
         it "raises an error" do
-          expect { formatter.format_messages_api_message_data({merge_language: "not_valid"}) }.to raise_error(MandrillMailer::CoreMailer::InvalidMergeLanguageError)
+          expect { formatter.format_messages_api_message_data({merge_language: "not_valid"}, {}) }.to raise_error(MandrillMailer::CoreMailer::InvalidMergeLanguageError)
         end
       end
     end
 
     context "merge_language does not exist" do
       it "does not raise an error" do
-        expect { formatter.format_messages_api_message_data({}) }.not_to raise_error
+        expect { formatter.format_messages_api_message_data({}, {}) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
The defaults I was setting (from, from_name) weren't being utilized in the API call