### PR TITLE
Add merge_language attribute documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ end
 
    * `:inline_css` - whether or not to automatically inline all CSS styles provided in the message HTML - only for HTML documents less than 256KB in size.
 
+   * `:merge_language` - the merge tag language to use when evaluating merge tags, either 'mailchimp' or 'handlebars'. Default is 'mailchimp'.
+
    * `:attachments` - An array of file objects with the following keys:
      * `content`: The file contents, this will be encoded into a base64 string internally
      * `name`: The name of the file


### PR DESCRIPTION
I wanted to use the Handlebars template language in my Mandrill template, but didn't see any mention of the `merge_language` attribute in the README file. Figuring the gem didn't yet support it, I forked the repository to add in the attribute setting, but then found the functionality already existed.

First - thanks for adding the functionality!

I just added a small line to the README that describes the setting in the `TemplateMailer` so that other folks know the functionality is there.