### PR TITLE
Allow default view_content_link on Mailer class

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ end
   * `:from` - set the default from email address for the mailer
   * `:from_name` - set the default from name for the mailer. If not set, defaults to from email address. Setting :from_name in the .mandrill_mail overrides the default.
   * `:merge_vars` - set some default `merge_vars` that will be sent with every mailer method (in `global_merge_vars` so there's no risk of collision with method-specific `merge_vars`.
+  * `:view_content_link` - set a default to be able to access individual mailer messages in the Mandrill dashboard
 
 * `.mandrill_mail`
    * `:template`(required) - Template slug from within Mandrill (for backwards-compatibility, the template name may also be used but the immutable slug is preferred)
@@ -184,6 +185,7 @@ class InvitationMailer < MandrillMailer::MessageMailer
                   # to: { email: invitation.email, name: 'Honored Guest' },
                   text: "Example text content",
                   html: "<p>Example HTML content</p>",
+                  # when you need to see the content of individual emails sent to users
                   view_content_link: true,
                   vars: {
                     'OWNER_NAME' => invitation.owner_name,

--- a/lib/mandrill_mailer/arg_formatter.rb
+++ b/lib/mandrill_mailer/arg_formatter.rb
@@ -92,7 +92,7 @@ module MandrillMailer
         "inline_css" => boolean(args[:inline_css]),
         "url_strip_qs" => boolean(args.fetch(:url_strip_qs, true)),
         "preserve_recipients" => boolean(args[:preserve_recipients]),
-        "view_content_link" => boolean(args[:view_content_link]),
+        "view_content_link" => boolean(args[:view_content_link] || defaults[:view_content_link]),
         "bcc_address" => args[:bcc],
         "tracking_domain" => args[:tracking_domain],
         "signing_domain" => args[:signing_domain],

--- a/lib/mandrill_mailer/core_mailer.rb
+++ b/lib/mandrill_mailer/core_mailer.rb
@@ -7,6 +7,7 @@
 #   default from: 'support@codeschool.com',
 #           from_name: 'Code School',
 #           merge_vars: { 'FOO' => 'Bar' }
+#           view_content_link: false
 
 #   def invite(invitation)
 #     invitees = invitation.invitees.map { |invitee| { email: invitee.email, name: invitee.name } }
@@ -36,9 +37,10 @@
 # end
 
 # #default:
-#   :from       - set the default from email address for the mailer
-#   :from_name  - set the default from name for the mailer
-#   :merge_vars - set the default merge vars for the mailer
+#   :from               - set the default from email address for the mailer
+#   :from_name          - set the default from name for the mailer
+#   :merge_vars         - set the default merge vars for the mailer
+#   :view_content_link  - set a default view_content_link option for the mailer
 
 # .mandrill_mail
 #   :template(required) - Template name from within Mandrill

--- a/lib/mandrill_mailer/template_mailer.rb
+++ b/lib/mandrill_mailer/template_mailer.rb
@@ -6,7 +6,8 @@
 # class InvitationMailer < MandrillMailer::TemplateMailer
 #   default from: 'support@codeschool.com',
 #           from_name: 'Code School',
-#           merge_vars: { 'FOO' => 'Bar' }
+#           merge_vars: { 'FOO' => 'Bar' },
+#           view_content_link: true
 
 #   def invite(invitation)
 #     invitees = invitation.invitees.map { |invitee| { email: invitee.email, name: invitee.name } }
@@ -36,7 +37,10 @@
 # end
 
 # #default:
-#   :from - set the default from email address for the mailer
+#   :from               - set the default from email address for the mailer
+#   :from_name          - set the default from name for the mailer
+#   :merge_vars         - set the default merge vars for the mailer
+#   :view_content_link  - set a default view_content_link option for the mailer
 
 # .mandrill_mail
 #   :template(required) - Template name from within Mandrill

--- a/spec/core_mailer_spec.rb
+++ b/spec/core_mailer_spec.rb
@@ -99,11 +99,13 @@ describe MandrillMailer::CoreMailer do
       default_from = "default name"
       default_from_email = "default@email.com"
       default_merge_vars = { foo: "bar" }
+      default_view_content_link = true
 
       unique_mailer = Class.new(core_mailer) do
         default from_name: default_from,
                 from: default_from_email,
-                merge_vars: default_merge_vars
+                merge_vars: default_merge_vars,
+                view_content_link: default_view_content_link
       end
 
       # Create a second mailer to make sure we don't get class var pollution
@@ -117,6 +119,7 @@ describe MandrillMailer::CoreMailer do
 
       expect(new_unique_mailer.message['from_name']).to eq default_from
       expect(new_unique_mailer.message['from_email']).to eq default_from_email
+      expect(new_unique_mailer.message['view_content_link']).to eq default_view_content_link
 
       global_merge_vars = [{ "name" => :foo, "content" => "bar" }]
       expect(new_unique_mailer.message['global_merge_vars']).to eq global_merge_vars
@@ -215,7 +218,7 @@ describe MandrillMailer::CoreMailer do
   end
 
   describe 'defaults' do
-    it 'should not share between different subclasses' do
+    it "doesn't share between different subclasses" do
       klassA = Class.new(core_mailer) do
         default from_name: 'ClassA'
       end
@@ -227,7 +230,7 @@ describe MandrillMailer::CoreMailer do
       expect(klassB.defaults[:from_name]).to eq 'ClassB'
     end
 
-    it 'should use defaults from the parent class' do
+    it 'uses defaults from the parent class' do
       klassA = Class.new(core_mailer) do
         default from_name: 'ClassA'
       end
@@ -237,7 +240,7 @@ describe MandrillMailer::CoreMailer do
       expect(klassB.defaults[:from_name]).to eq 'ClassA'
     end
 
-    it 'should allow overriding defaults from the parent' do
+    it 'allows overriding defaults from the parent' do
       klassA = Class.new(core_mailer) do
         default from_name: 'ClassA'
       end


### PR DESCRIPTION
This is something that @jamesmichiemo noticed we needed since we
was setting this in mailer methods all over the place.

You can now set a default view_content_link in either your Mailer class or
your BaseMailer class. Just like the other defaults, this one cascades
down and can be overidden at the Mailer class level or the method level.