### PR TITLE
Add RSpec::Helper module with customer matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 - 2015-10-02
+### Added
+- Optional RSpec helper (`MandrillMailer::RSpecHelper`) with custom matchers
+to simplify testing mailers like:
+  - `expect(mailer).to be_from("email@example.com")`
+  - `expect(mailer).to have_merge_data('USER_EMAIL' => user.email)`
+  - `expect(mailer).to include_merge_var_content(user.email)`
+  - `expect(mailer).to have_subject("Hello")`
+  - `expect(mailer).to use_template('Example')`
+  - `expect(mailer).to send_email_to('email@example.com')`
+
+
 ## 1.0.4 - 2015-09-24
 ### Added
 - Allow default `view_content_link` on Mailer class.

--- a/lib/mandrill_mailer/rspec_helper.rb
+++ b/lib/mandrill_mailer/rspec_helper.rb
@@ -1,0 +1,10 @@
+module MandrillMailer
+  module RSpecHelper
+    require 'mandrill_mailer/rspec_helpers/from_matcher'
+    require 'mandrill_mailer/rspec_helpers/merge_var_matcher'
+    require 'mandrill_mailer/rspec_helpers/merge_var_content_matcher'
+    require 'mandrill_mailer/rspec_helpers/subject_matcher'
+    require 'mandrill_mailer/rspec_helpers/template_matcher'
+    require 'mandrill_mailer/rspec_helpers/to_email_matcher'
+  end
+end

--- a/lib/mandrill_mailer/rspec_helper.rb
+++ b/lib/mandrill_mailer/rspec_helper.rb
@@ -1,3 +1,34 @@
+# MandrilMailer helper module that requires custom matchers for use in RSpec specs.
+# Example usage:
+#
+# In spec/spec_helper.rb):
+#
+# RSpec.configure do |config|
+#   # ...
+#   require "mandrill_mailer/rspec_helpers"
+#   config.include MandrillMailer::RSpecHelper
+# end
+#
+# In spec/mailers/user_mailer_spec.rb):
+#
+# require "rails_helper"
+#s
+# RSpec.describe UserMailer do
+#   let(:user) { create(:user) }
+#
+#   context ".welcome" do
+#     let(:mailer) { described_class.welcome(user) }
+#
+#     subject { mailer }
+#
+#     it 'has the correct data' do
+#       expect(mailer).to use_template('Welcome')
+#     end
+#   end
+# end
+#
+#
+
 module MandrillMailer
   module RSpecHelper
     require 'mandrill_mailer/rspec_helpers/from_matcher'

--- a/lib/mandrill_mailer/rspec_helpers/from_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/from_matcher.rb
@@ -8,7 +8,7 @@
 #
 # let(:user) { create(:user) }
 # let(:mailer) { WelcomeMailer.welcome_registered(user) }
-# it 'should have the correct data' do
+# it 'has the correct data' do
 #   expect(mailer).to be_from('support@codeschool.com')
 # end
 #

--- a/lib/mandrill_mailer/rspec_helpers/from_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/from_matcher.rb
@@ -1,0 +1,47 @@
+# Public: Matcher for asserting from email
+#
+# expected_options - The Hash options used to refine the selection (default: {}):
+#             :email - expected from email
+#             :name - expected from name
+#
+# WelcomeMailer is an instance of MandrillMailler::TemplateMailer
+#
+# let(:user) { create(:user) }
+# let(:mailer) { WelcomeMailer.welcome_registered(user) }
+# it 'should have the correct data' do
+#   expect(mailer).to be_from('support@codeschool.com')
+# end
+#
+# Returns true or an error message on failure
+#
+RSpec::Matchers.define :be_from do |expected_options|
+  match do |mailer|
+    bool_arr = [(mailer_from_email(mailer) == expected_options[:email] if expected_options[:email]),
+    (mailer_from_name(mailer) == expected_options[:name] if expected_options[:name])]
+    !bool_arr.compact.any? {|i| i == false}
+  end
+
+  failure_message_for_should do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected from vars: #{mailer_from_email(mailer).inspect} to be: #{expected_options.inspect}.
+  MESSAGE
+  end
+
+  failure_message_for_should_not do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected from vars: #{mailer_from_email(mailer).inspect} to not be: #{expected_options.inspect}.
+  MESSAGE
+  end
+
+  description do
+    "be the same from vars as #{expected_options.inspect}"
+  end
+
+  def mailer_from_email(mailer)
+    mailer.message['from_email']
+  end
+
+  def mailer_from_name(mailer)
+    mailer.message['from_name']
+  end
+end

--- a/lib/mandrill_mailer/rspec_helpers/merge_var_content_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/merge_var_content_matcher.rb
@@ -1,0 +1,49 @@
+# Public: Matcher for asserting specific merge vars content contains something.
+#
+# expected_data - Data to look for in the specified merge var key.
+#
+# WelcomeMailer is an instance of MandrillMailler::TemplateMailer
+#
+# let(:user) { FactoryGirl.create(:user) }
+# let(:mailer) { WelcomeMailer.welcome_registered(user) }
+# it 'should have the correct data' do
+#   expect(mailer).to include_merge_var_content(user.email)
+# end
+#
+# Returns true or an error message on failure
+#
+RSpec::Matchers.define :include_merge_var_content do |expected_data|
+  match do |actual|
+    has_match = false
+
+    matches = merge_vars_from(actual).find do |hash|
+      hash['name'] == 'CONTENT'
+    end
+
+    has_match = matches['content'].include?(expected_data)
+
+    has_match
+  end
+
+  failure_message do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected merge variables: #{merge_vars_from(actual).inspect} to include content: #{expected_data}.
+  MESSAGE
+  end
+
+  failure_message_when_negated do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected merge variables: #{merge_vars_from(actual).inspect} to not include content: #{expected_data}.
+  MESSAGE
+  end
+
+  description do
+    "include merge var content: #{expected_data}"
+  end
+
+  def merge_vars_from(mailer)
+    # Merge vars are in format:
+    # [{"name"=>"USER_EMAIL", "content"=>"zoila@homenick.name"},{"name"=>"USER_NAME", "content"=>"Bob"}]
+    mailer.message['global_merge_vars']
+  end
+end

--- a/lib/mandrill_mailer/rspec_helpers/merge_var_content_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/merge_var_content_matcher.rb
@@ -6,7 +6,7 @@
 #
 # let(:user) { FactoryGirl.create(:user) }
 # let(:mailer) { WelcomeMailer.welcome_registered(user) }
-# it 'should have the correct data' do
+# it 'has the correct data' do
 #   expect(mailer).to include_merge_var_content(user.email)
 # end
 #

--- a/lib/mandrill_mailer/rspec_helpers/merge_var_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/merge_var_matcher.rb
@@ -1,0 +1,48 @@
+# Public: Matcher for asserting merge vars have certain data.
+#
+# expected_data - Data to compare to the merge vars
+#
+# WelcomeMailer is an instance of MandrillMailler::TemplateMailer
+#
+# let(:user) { create(:user) }
+# let(:mailer) { WelcomeMailer.welcome_registered(user) }
+# it 'should have the correct data' do
+#   expect(mailer).to have_merge_data('USER_EMAIL' => user.email)
+# end
+#
+# Returns true or an error message on failure
+#
+RSpec::Matchers.define :have_merge_data do |expected_data|
+  match do |actual|
+    has_match = false
+    expected_data.each_pair do |key, value|
+      has_match = merge_vars_from(actual).any? do |obj|
+        obj['name'] == key && obj['content'] == value
+      end
+      break unless has_match
+    end
+    has_match
+  end
+
+  failure_message_for_should do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected merge variables: #{merge_vars_from(actual).inspect} to include data: #{expected_data.inspect} but it does not.
+  MESSAGE
+  end
+
+  failure_message_for_should_not do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected merge variables: #{merge_vars_from(actual).inspect} to not include data: #{expected_data.inspect} but it does.
+  MESSAGE
+  end
+
+  description do
+    "be the same data as #{expected_data.inspect}"
+  end
+
+  def merge_vars_from(mailer)
+    # Merge vars are in format:
+    # [{"name"=>"USER_EMAIL", "content"=>"zoila@homenick.name"},{"name"=>"USER_NAME", "content"=>"Bob"}]
+    mailer.message['global_merge_vars']
+  end
+end

--- a/lib/mandrill_mailer/rspec_helpers/merge_var_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/merge_var_matcher.rb
@@ -6,7 +6,7 @@
 #
 # let(:user) { create(:user) }
 # let(:mailer) { WelcomeMailer.welcome_registered(user) }
-# it 'should have the correct data' do
+# it 'has the correct data' do
 #   expect(mailer).to have_merge_data('USER_EMAIL' => user.email)
 # end
 #

--- a/lib/mandrill_mailer/rspec_helpers/subject_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/subject_matcher.rb
@@ -6,7 +6,7 @@
 #
 # let(:user) { create(:user) }
 # let(:mailer) { WelcomeMailer.welcome_registered(user) }
-# it 'should have the correct data' do
+# it 'has the correct data' do
 #   expect(mailer).to have_subject('Welcome Subscriber')
 # end
 #

--- a/lib/mandrill_mailer/rspec_helpers/subject_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/subject_matcher.rb
@@ -1,0 +1,39 @@
+# Public: Matcher for asserting subject
+#
+#   expected_subject: - Expected subject of email
+#
+# WelcomeMailer is an instance of MandrillMailler::TemplateMailer
+#
+# let(:user) { create(:user) }
+# let(:mailer) { WelcomeMailer.welcome_registered(user) }
+# it 'should have the correct data' do
+#   expect(mailer).to have_subject('Welcome Subscriber')
+# end
+#
+# Returns true or an error message on failure
+#
+RSpec::Matchers.define :have_subject do |expected_subject|
+  match do |mailer|
+    mailer_subject(mailer) == expected_subject
+  end
+
+  failure_message_for_should do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected subject: #{mailer_subject(mailer).inspect} to be: #{expected_subject.inspect}.
+  MESSAGE
+  end
+
+  failure_message_for_should_not do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected subject: #{mailer_subject(mailer).inspect} to not be: #{expected_subject.inspect}.
+  MESSAGE
+  end
+
+  description do
+    "be the same subject as #{expected_subject.inspect}"
+  end
+
+  def mailer_subject(mailer)
+    mailer.message['subject']
+  end
+end

--- a/lib/mandrill_mailer/rspec_helpers/template_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/template_matcher.rb
@@ -6,7 +6,7 @@
 #
 # let(:user) { create(:user) }
 # let(:mailer) { WelcomeMailer.welcome_registered(user) }
-# it 'should have the correct data' do
+# it 'has the correct data' do
 #   expect(mailer).to use_template('Welcome Subscriber')
 # end
 #

--- a/lib/mandrill_mailer/rspec_helpers/template_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/template_matcher.rb
@@ -1,0 +1,39 @@
+# Public: Matcher for asserting template
+#
+#   template_name: - name of template in mandrill the mailer sends to
+#
+# WelcomeMailer is an instance of MandrillMailler::TemplateMailer
+#
+# let(:user) { create(:user) }
+# let(:mailer) { WelcomeMailer.welcome_registered(user) }
+# it 'should have the correct data' do
+#   expect(mailer).to use_template('Welcome Subscriber')
+# end
+#
+# Returns true or an error message on failure
+#
+RSpec::Matchers.define :use_template do |expected_template|
+  match do |mailer|
+    mailer_template(mailer) == expected_template
+  end
+
+  failure_message_for_should do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected template: #{mailer_template(mailer).inspect} to be: #{expected_template.inspect}.
+  MESSAGE
+  end
+
+  failure_message_for_should_not do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected template: #{mailer_template(mailer).inspect} to not be: #{expected_template.inspect}.
+  MESSAGE
+  end
+
+  description do
+    "be the same template as #{expected_template.inspect}"
+  end
+
+  def mailer_template(mailer)
+    mailer.template_name
+  end
+end

--- a/lib/mandrill_mailer/rspec_helpers/to_email_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/to_email_matcher.rb
@@ -1,0 +1,63 @@
+# Public: Matcher for asserting to email
+#
+# expected_to - The Hash options used to designate to whom the email is sent, options are optional (default: {}):
+#             :name - Name of reciever
+#             :email - email of reciever
+#
+# WelcomeMailer is an instance of MandrillMailler::TemplateMailer
+#
+# let(:user) { create(:user) }
+# let(:mailer) { WelcomeMailer.welcome_registered(user) }
+# it 'has the correct data' do
+#   expect(mailer).to send_email_to(email: user.email, name: 'Code School Customer')
+# end
+#
+# it 'has the correct to name' do
+#   expect(mailer).to send_email_to(name: 'Code School Customer')
+# end
+#
+# it 'has the correct email' do
+#   expect(mailer).to send_email_to(email: user.email')
+# end
+#
+# Returns true or an error message on failure
+#
+RSpec::Matchers.define :send_email_to do |expected_to|
+  match do |mailer|
+    to_arr = mailer_to_data(mailer)
+    opts_found = false
+    expected_to.each_pair do |key, value|
+      opts_found = to_arr.any? do |to_opt|
+        to_opt.symbolize_keys!
+        bool_arr = [
+          (to_opt[:email] == value if key.to_sym == :email),
+          (to_opt[:name] == value if key.to_sym == :name)
+        ]
+        !bool_arr.compact.any? {|i| i == false}
+      end
+      break unless opts_found
+    end
+    opts_found
+  end
+
+  failure_message_for_should do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected to variables: #{mailer_to_data(mailer).inspect} to include data: #{expected_to.inspect} but it does not.
+  MESSAGE
+  end
+
+  failure_message_for_should_not do |actual|
+    <<-MESSAGE.strip_heredoc
+    Expected to variables: #{mailer_to_data(mailer).inspect} to not include data: #{expected_to.inspect} but it does.
+  MESSAGE
+  end
+
+  description do
+    "be the same to data as #{expected_to.inspect}"
+  end
+
+  def mailer_to_data(mailer)
+    # {email: 'user@email.com', name: 'larry'}
+    mailer.message['to']
+  end
+end

--- a/lib/mandrill_mailer/version.rb
+++ b/lib/mandrill_mailer/version.rb
@@ -1,3 +1,3 @@
 module MandrillMailer
-  VERSION = "1.0.4"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
This is something I discussed way back with @renz45 and finally got
around to doing because I was tired of having mismatching customer
matchers on Orientation.