### PR TITLE
Document the default values for `from` and `view_content_link`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ end
 ```
 
 * `#default:`
-  * `:from` - set the default from email address for the mailer
+  * `:from` - set the default from email address for the mailer.  Defaults to `'example@email.com'`.
   * `:from_name` - set the default from name for the mailer. If not set, defaults to from email address. Setting :from_name in the .mandrill_mail overrides the default.
   * `:merge_vars` - set some default `merge_vars` that will be sent with every mailer method (in `global_merge_vars` so there's no risk of collision with method-specific `merge_vars`.
-  * `:view_content_link` - set a default to be able to access individual mailer messages in the Mandrill dashboard
+  * `:view_content_link` - set a default to be able to access individual mailer messages in the Mandrill dashboard. Defaults to `false`.
 
 * `.mandrill_mail`
    * `:template`(required) - Template slug from within Mandrill (for backwards-compatibility, the template name may also be used but the immutable slug is preferred)


### PR DESCRIPTION
As mentioned in https://github.com/renz45/mandrill_mailer/commit/5d68fd269e476ce00178603560e5f3b2c12d439e we were recently bit/surprised by the default defaults. This change attempts to make the defaults more explicit to new users of mandrill_mailer.