### PR TITLE
Instatiate the mailer class when sending later.

### DIFF
--- a/lib/mandrill_mailer/mandrill_message_later.rb
+++ b/lib/mandrill_mailer/mandrill_message_later.rb
@@ -2,12 +2,12 @@ require 'mandrill_mailer/message_mailer'
 module MandrillMailer
   class MandrillMessageJob < ActiveJob::Base
     queue_as { MandrillMailer.config.deliver_later_queue_name }
- 
-    def perform(message, async, ip_pool, send_at)
-      mailer = MandrillMailer::MessageMailer.new
+
+    def perform(mailer, message, async, ip_pool, send_at)
+      mailer = mailer.constantize.new
       mailer.message = message
       mailer.async = async
-      mailer.ip_pool = ip_pool 
+      mailer.ip_pool = ip_pool
       mailer.send_at = send_at
       mailer.deliver_now
     end

--- a/lib/mandrill_mailer/mandrill_message_later.rb
+++ b/lib/mandrill_mailer/mandrill_message_later.rb
@@ -3,7 +3,7 @@ module MandrillMailer
   class MandrillMessageJob < ActiveJob::Base
     queue_as { MandrillMailer.config.deliver_later_queue_name }
 
-    def perform(mailer, message, async, ip_pool, send_at)
+    def perform(message, async, ip_pool, send_at, mailer='MandrillMailer::MessageMailer')
       mailer = mailer.constantize.new
       mailer.message = message
       mailer.async = async

--- a/lib/mandrill_mailer/mandrill_template_later.rb
+++ b/lib/mandrill_mailer/mandrill_template_later.rb
@@ -3,7 +3,7 @@ module MandrillMailer
   class MandrillTemplateJob < ActiveJob::Base
     queue_as { MandrillMailer.config.deliver_later_queue_name }
 
-    def perform(mailer, template_name, template_content, message, async, ip_pool, send_at)
+    def perform(template_name, template_content, message, async, ip_pool, send_at, mailer='MandrillMailer::TemplateMailer')
       mailer = mailer.constantize.new
       mailer.template_name = template_name
       mailer.template_content = template_content

--- a/lib/mandrill_mailer/mandrill_template_later.rb
+++ b/lib/mandrill_mailer/mandrill_template_later.rb
@@ -3,13 +3,13 @@ module MandrillMailer
   class MandrillTemplateJob < ActiveJob::Base
     queue_as { MandrillMailer.config.deliver_later_queue_name }
 
-    def perform(template_name, template_content, message, async, ip_pool, send_at)
-      mailer = MandrillMailer::TemplateMailer.new
+    def perform(mailer, template_name, template_content, message, async, ip_pool, send_at)
+      mailer = mailer.constantize.new
       mailer.template_name = template_name
       mailer.template_content = template_content
       mailer.message = message
       mailer.async = async
-      mailer.ip_pool = ip_pool 
+      mailer.ip_pool = ip_pool
       mailer.send_at = send_at
       mailer.deliver_now
     end

--- a/lib/mandrill_mailer/message_mailer.rb
+++ b/lib/mandrill_mailer/message_mailer.rb
@@ -105,7 +105,7 @@ module MandrillMailer
     end
 
     def deliver_later(options={})
-      MandrillMailer::MandrillMessageJob.set(options).perform_later(self.class.name, message, async, ip_pool, send_at)
+      MandrillMailer::MandrillMessageJob.set(options).perform_later(message, async, ip_pool, send_at, self.class.name)
     end
   end
 end

--- a/lib/mandrill_mailer/message_mailer.rb
+++ b/lib/mandrill_mailer/message_mailer.rb
@@ -105,7 +105,7 @@ module MandrillMailer
     end
 
     def deliver_later(options={})
-      MandrillMailer::MandrillMessageJob.set(options).perform_later(message, async, ip_pool, send_at)
+      MandrillMailer::MandrillMessageJob.set(options).perform_later(self.class.name, message, async, ip_pool, send_at)
     end
   end
 end

--- a/lib/mandrill_mailer/template_mailer.rb
+++ b/lib/mandrill_mailer/template_mailer.rb
@@ -127,7 +127,7 @@ module MandrillMailer
     end
 
     def deliver_later(options={})
-      MandrillMailer::MandrillTemplateJob.set(options).perform_later(self.class.name, template_name, template_content, message, async, ip_pool, send_at)
+      MandrillMailer::MandrillTemplateJob.set(options).perform_later(template_name, template_content, message, async, ip_pool, send_at, self.class.name)
     end
 
     # Handle template mailer specifics before formating the given args

--- a/lib/mandrill_mailer/template_mailer.rb
+++ b/lib/mandrill_mailer/template_mailer.rb
@@ -127,7 +127,7 @@ module MandrillMailer
     end
 
     def deliver_later(options={})
-      MandrillMailer::MandrillTemplateJob.set(options).perform_later(template_name, template_content, message, async, ip_pool, send_at)
+      MandrillMailer::MandrillTemplateJob.set(options).perform_later(self.class.name, template_name, template_content, message, async, ip_pool, send_at)
     end
 
     # Handle template mailer specifics before formating the given args


### PR DESCRIPTION
Out of the box this code is essentially a no-op but if the subclass
has overridden functionality in the base mailer this ensures that
overwritten functionality happens.

I use this primarily to override `deliver_now` so that I can extract
the mandril response the the REST call and store the message id's
locally. Example:

    # Override to record the message id with each lead so we know when we last
    # communicated with a given lead. This also works even if `deliver_later` is
    # called as `deliver_later` internally calls `deliver_now`.
    def deliver_now
      super.tap do |results|
        emails = results.collect {|r| r['email']}
        leads = Lead.where(email: emails).index_by &:email
        for result in results
          leads[result['email']].communications.create! message_id: result['_id']
        end
      end
    end