### PR TITLE
Enqueue offline

### DIFF
--- a/lib/mandrill_mailer/offline.rb
+++ b/lib/mandrill_mailer/offline.rb
@@ -26,23 +26,7 @@ module MandrillMailer
   end
 
   class TemplateMailer
-    def deliver
-      deliver_now
-    end
-    
     def deliver_now
-      MandrillMailer::Mock.new({
-        :template_name    => template_name,
-        :template_content => template_content,
-        :message          => message,
-        :async            => async,
-        :ip_pool          => ip_pool,
-        :send_at          => send_at
-      }).tap do |mock|
-         MandrillMailer.deliveries << mock
-      end
-    end
-    def deliver_later
       MandrillMailer::Mock.new({
         :template_name    => template_name,
         :template_content => template_content,
@@ -57,20 +41,7 @@ module MandrillMailer
   end
 
   class MessageMailer
-    def deliver
-      deliver_now
-    end
     def deliver_now
-      MandrillMailer::Mock.new({
-        :message          => message,
-        :async            => async,
-        :ip_pool          => ip_pool,
-        :send_at          => send_at
-      }).tap do |mock|
-         MandrillMailer.deliveries << mock
-      end
-    end
-    def deliver_later
       MandrillMailer::Mock.new({
         :message          => message,
         :async            => async,

--- a/spec/core_mailer_spec.rb
+++ b/spec/core_mailer_spec.rb
@@ -179,7 +179,7 @@ describe MandrillMailer::CoreMailer do
 
     context 'Rails is not defined' do
       it 'should raise an exception' do
-        expect{subject}.to raise_error
+        expect{subject}.to raise_error NoMethodError
       end
     end
   end
@@ -212,7 +212,7 @@ describe MandrillMailer::CoreMailer do
 
     context 'Rails does not exist' do
       it 'should raise exception' do
-        expect{ subject }.to raise_error
+        expect{ subject }.to raise_error NoMethodError
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ require 'pry'
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
+ActiveJob::Base.queue_adapter = :inline
+
 RSpec.configure do |config|
   config.mock_with :rspec
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'pry'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 ActiveJob::Base.queue_adapter = :inline
+ActiveJob::Base.logger.level = Logger::WARN
 
 RSpec.configure do |config|
   config.mock_with :rspec


### PR DESCRIPTION
dba18c9 is really the goal of my PR. I want offline mails to be enqueued just like ActionMailer. My personal need is for the normal instrumentation events to kick off but it also has the following advantages:

* Better parity with ActionMailer.
* Ability for calling code to decide if it should immediately queue or queue later.

The other commits are entirely just some cleanup to make the test run cleanly. Quick summary:

* 5ed0580 - Allows tests to pass under Rails 5 where the default adapter is `async` now. Test were assuming `inline` (old default)
* faeab9c - Removal of rspec deprecation warning.
* 180a2ca - Removal of logging noise when tests run

Each commit message has further info if desired.