### PR TITLE
Use my fork of the mandrill-api gem to support json 2.x+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.7.0 - 2018-10-06
+- Switch to mandrillus fork of the mandrill-api gem to allow for newer
+json gem support
+
 ## 1.6.0 - 2017-03-23
 - Add support for attaching unencoded content via @brunomperes
 

--- a/lib/mandrill_mailer/version.rb
+++ b/lib/mandrill_mailer/version.rb
@@ -1,3 +1,3 @@
 module MandrillMailer
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end

--- a/mandrill_mailer.gemspec
+++ b/mandrill_mailer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport'
   s.add_dependency 'actionpack'
   s.add_dependency 'activejob'
-  s.add_runtime_dependency 'mandrill-api', '~> 1.0.9'
+  s.add_runtime_dependency 'mandrillus', '~> 2.0.0'
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'

--- a/mandrill_mailer.gemspec
+++ b/mandrill_mailer.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = MandrillMailer::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Adam Rensel"]
-  s.email       = ["adamrensel@codeschool.com"]
+  s.email       = ["adamrensel@gmail.com"]
   s.homepage    = "https://github.com/renz45/mandrill_mailer"
   s.summary     = %q{Transactional Mailer for Mandrill}
   s.description = %q{Transactional Mailer for Mandrill}


### PR DESCRIPTION
Still using mandrill_mailer in https://github.com/orientation/orientation/ but sick of being stuck on an antiquated json gem because of this completely unmaintained official Mandrill gem so whoop there it is I forked the official gem and put it on github at https://github.com/olivierlacan/mandrillus/ and on RubyGems at https://rubygems.org/gems/mandrillus.

Nothing has changed except the version dependency on `json` is `s.add_dependency 'json', '>= 1.7.7', '< 3.0'` instead of `s.add_dependency 'json', '>= 1.7.7', '< 2.0'`. See: https://rubygems.org/gems/json

Bumped the minor version because although it doesn't change the API one bit (everything is the same) it didn't feel like something small enough for a patch release since it opens up `json` gem support for modern versions that may cause API breakage for some folks since: https://github.com/flori/json/blob/master/CHANGES.md#2015-09-11-200