### PR TITLE
Correct failure message on RSpec expectations to have_merge_data

### DIFF
--- a/lib/mandrill_mailer/rspec_helpers/merge_var_matcher.rb
+++ b/lib/mandrill_mailer/rspec_helpers/merge_var_matcher.rb
@@ -30,7 +30,7 @@ RSpec::Matchers.define :have_merge_data do |expected_data|
   MESSAGE
   end
 
-  failure_message do |actual|
+  failure_message_when_negated do |actual|
     <<-MESSAGE.strip_heredoc
     Expected merge variables: #{merge_vars_from(actual).inspect} to not include data: #{expected_data.inspect} but it does.
   MESSAGE


### PR DESCRIPTION
We were getting some pretty mysterious failure messages from our specs, and it turns out to have been an issue with overwriting the positive failure message in the `have_merge_data` matcher.