### PR TITLE
Ruby 3.0.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - 3.0
     steps: 
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/lib/mandrill_mailer/core_mailer.rb
+++ b/lib/mandrill_mailer/core_mailer.rb
@@ -290,11 +290,16 @@ module MandrillMailer
     end
 
     # Makes this class act as a singleton without it actually being a singleton
-    # This keeps the syntax the same as the orginal mailers so we can swap quickly if something
+    # This keeps the syntax the same as the original mailers so we can swap quickly if something
     # goes wrong.
-    def self.method_missing(method, *args, **kwargs)
-      return super unless respond_to?(method)
-      new.method(method).call(*args, **kwargs)
+
+    class << self
+      def method_missing(method, *args, &block)
+        return super unless respond_to?(method)
+        new.method(method).call(*args, &block)
+      end
+
+      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
 
     def self.respond_to?(method, include_private = false)

--- a/lib/mandrill_mailer/core_mailer.rb
+++ b/lib/mandrill_mailer/core_mailer.rb
@@ -292,9 +292,9 @@ module MandrillMailer
     # Makes this class act as a singleton without it actually being a singleton
     # This keeps the syntax the same as the orginal mailers so we can swap quickly if something
     # goes wrong.
-    def self.method_missing(method, *args)
+    def self.method_missing(method, *args, **kwargs)
       return super unless respond_to?(method)
-      new.method(method).call(*args)
+      new.method(method).call(*args, **kwargs)
     end
 
     def self.respond_to?(method, include_private = false)


### PR DESCRIPTION
👋 [ Ruby 3.0.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) does not make automatic conversion on keyword arguments into a Hash anymore.

Instead we need to specific pass keyword arguments with the `**` operator.


**Note**: For a reason [CI outcome](https://travis-ci.org/github/renz45/mandrill_mailer/builds/753929182) is not being displayed to Github. It might be related with PR being draft at some point.